### PR TITLE
fix: satisfy react/jsx-boolean-value in AccountsHeader

### DIFF
--- a/src/client/v2/src/components/AccountsHeader/AccountsHeader.story.tsx
+++ b/src/client/v2/src/components/AccountsHeader/AccountsHeader.story.tsx
@@ -96,7 +96,7 @@ export function Loading() {
       <AccountsHeader
         currentAccount={null}
         accounts={[]}
-        loadingAccounts={true}
+        loadingAccounts
         onAccountChange={noop}
         onAddAccount={noop}
       />

--- a/src/client/v2/src/components/AccountsHeader/AccountsHeader.test.tsx
+++ b/src/client/v2/src/components/AccountsHeader/AccountsHeader.test.tsx
@@ -146,7 +146,7 @@ describe('AccountsHeader', () => {
       <AccountsHeader
         currentAccount={null}
         accounts={[]}
-        loadingAccounts={true}
+        loadingAccounts
         onAccountChange={noop}
         onAddAccount={noop}
       />


### PR DESCRIPTION
## What

Change `loadingAccounts={true}` to the shorthand `loadingAccounts` in two files:
- `src/client/v2/src/components/AccountsHeader/AccountsHeader.story.tsx`
- `src/client/v2/src/components/AccountsHeader/AccountsHeader.test.tsx`

## Why

These two spots tripped the `react/jsx-boolean-value` eslint rule, which requires the value be omitted for boolean JSX attributes. The errors predate current work and were causing `npm run lint` to fail.

## Notes

Ran `npm run eslint` in `src/client/v2` afterwards — clean, no reported errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)