### PR TITLE
feat: reactively sync accounts view with include-in-analytics toggles

### DIFF
--- a/src/client/v2/src/components/AddAccountModal/AddAccountModal.tsx
+++ b/src/client/v2/src/components/AddAccountModal/AddAccountModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useMutation } from '@apollo/client/react';
 import { Button, CloseButton, Modal, Stack, Text, Title } from '@mantine/core';
+import { useFlushAnalyticsRefetchOnClose } from '@/components/IncludeInAnalyticsSwitch/DeferredAnalyticsRefetch';
 import { CreateAuthenticationRequest } from '@/graphql/mutations/CreateAuthenticationRequest';
 import { AuthenticateBankStep } from './steps/AuthenticateBankStep/AuthenticateBankStep';
 import {
@@ -24,6 +25,7 @@ interface AddAccountModalProps {
 }
 
 export function AddAccountModal({ opened, onClose, pendingAuth }: AddAccountModalProps) {
+  useFlushAnalyticsRefetchOnClose(opened);
   const [step, setStep] = useState<1 | 2 | 3>(1);
   const [selectedType, setSelectedAccountType] = useState<AccountType | undefined>(undefined);
   const [selectedBank, setSelectedBank] = useState<string | undefined>(undefined);

--- a/src/client/v2/src/components/IncludeInAnalyticsSwitch/DeferredAnalyticsRefetch.tsx
+++ b/src/client/v2/src/components/IncludeInAnalyticsSwitch/DeferredAnalyticsRefetch.tsx
@@ -1,0 +1,82 @@
+import { createContext, ReactNode, useContext, useEffect, useMemo, useRef } from 'react';
+import { useApolloClient } from '@apollo/client/react';
+import { GetBankAccounts } from '@graphql-queries/GetBankAccounts';
+import { GetNetWorthHistory } from '@graphql-queries/GetNetWorthHistory';
+
+interface AnalyticsRefetchContextValue {
+  /** Marks the analytics queries as needing a refetch on the next flush. */
+  markDirty: () => void;
+  /** Refetches the analytics queries if anything was marked dirty since the last flush. */
+  flush: () => void;
+}
+
+const AnalyticsRefetchContext = createContext<AnalyticsRefetchContextValue | null>(null);
+
+/**
+ * Returns a callback that marks the analytics queries as needing a refetch, or `null` when used
+ * outside a {@link DeferredAnalyticsRefetchProvider}. Consumers call it after mutating a value that
+ * affects the analytics result sets (e.g. toggling `includeInAnalytics`).
+ */
+export function useMarkAnalyticsDirty() {
+  return useContext(AnalyticsRefetchContext)?.markDirty ?? null;
+}
+
+/**
+ * Flushes any pending analytics refetch when `opened` transitions from `true` to `false`, i.e. when
+ * a surface hosting analytics toggles (such as the settings or add account modal) is closed. This
+ * lets the provider live once near the app root while the refetch still fires at the right moment,
+ * without churning the UI on every individual toggle.
+ */
+export function useFlushAnalyticsRefetchOnClose(opened: boolean) {
+  const context = useContext(AnalyticsRefetchContext);
+  const wasOpen = useRef(opened);
+
+  useEffect(() => {
+    if (wasOpen.current && !opened) {
+      context?.flush();
+    }
+    wasOpen.current = opened;
+  }, [opened, context]);
+}
+
+interface DeferredAnalyticsRefetchProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * Provides deferred refetching of the analytics queries (accounts view, net worth chart) to its
+ * subtree. Descendants mark the queries dirty via {@link useMarkAnalyticsDirty} when they change a
+ * value the queries filter on server-side (`includeInAnalytics`), which Apollo can't re-evaluate
+ * against its cache. The refetch is deferred until a surface is closed via
+ * {@link useFlushAnalyticsRefetchOnClose} so that toggling doesn't churn the surrounding UI, and is
+ * batched into a single refetch regardless of how many toggles happened.
+ *
+ * Intended to be mounted once near the app root so any page or modal can participate without
+ * wrapping its own subtree.
+ */
+export function DeferredAnalyticsRefetchProvider({
+  children,
+}: DeferredAnalyticsRefetchProviderProps) {
+  const client = useApolloClient();
+  const dirtyRef = useRef(false);
+
+  const value = useMemo<AnalyticsRefetchContextValue>(
+    () => ({
+      markDirty: () => {
+        dirtyRef.current = true;
+      },
+      flush: () => {
+        if (!dirtyRef.current) {
+          return;
+        }
+        dirtyRef.current = false;
+        void client.refetchQueries({ include: [GetBankAccounts, GetNetWorthHistory] });
+      },
+    }),
+    [client]
+  );
+
+  return (
+    <AnalyticsRefetchContext.Provider value={value}>{children}</AnalyticsRefetchContext.Provider>
+  );
+}

--- a/src/client/v2/src/components/IncludeInAnalyticsSwitch/IncludeInAnalyticsSwitch.tsx
+++ b/src/client/v2/src/components/IncludeInAnalyticsSwitch/IncludeInAnalyticsSwitch.tsx
@@ -1,7 +1,8 @@
 import { ChangeEvent } from 'react';
 import { useMutation } from '@apollo/client/react';
-import { Switch } from '@mantine/core';
 import { SetBankAccountIncludeInAnalytics } from '@graphql-mutations/SetBankAccountIncludeInAnalytics';
+import { Switch } from '@mantine/core';
+import { useMarkAnalyticsDirty } from './DeferredAnalyticsRefetch';
 
 interface IncludeInAnalyticsSwitchProps {
   /** The id of the bank account whose inclusion state is being controlled. */
@@ -20,6 +21,12 @@ interface IncludeInAnalyticsSwitchProps {
  * The `checked` state is derived from the passed in prop rather than local state so that the switch
  * always reflects the cached value. An optimistic response makes the toggle feel instant and
  * automatically reverts if the mutation fails.
+ *
+ * The analytics queries filter server-side on `includeInAnalytics`, so toggling the flag can add or
+ * remove an account from those result sets, which Apollo can't re-evaluate against its cache. Rather
+ * than refetch on every toggle (which churns the surrounding UI mid-interaction), we mark the
+ * analytics queries dirty and let {@link DeferredAnalyticsRefetchProvider} refetch once the user
+ * leaves the settings.
  */
 export function IncludeInAnalyticsSwitch({
   accountId,
@@ -27,6 +34,7 @@ export function IncludeInAnalyticsSwitch({
   size = 'sm',
 }: IncludeInAnalyticsSwitchProps) {
   const [setIncludeInAnalytics] = useMutation(SetBankAccountIncludeInAnalytics);
+  const markAnalyticsDirty = useMarkAnalyticsDirty();
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const nextValue = event.currentTarget.checked;
@@ -44,6 +52,8 @@ export function IncludeInAnalyticsSwitch({
         },
       },
     });
+
+    markAnalyticsDirty?.();
   };
 
   return (

--- a/src/client/v2/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/client/v2/src/components/SettingsModal/SettingsModal.tsx
@@ -9,6 +9,7 @@ import {
   IconUser,
 } from '@tabler/icons-react';
 import { CloseButton, Modal, NavLink, ScrollArea, Text, Title } from '@mantine/core';
+import { useFlushAnalyticsRefetchOnClose } from '@/components/IncludeInAnalyticsSwitch/DeferredAnalyticsRefetch';
 import { AboutSection } from './sections/AboutSection/AboutSection';
 import { ConnectedBanksSection } from './sections/ConnectedBanksSection/ConnectedBanksSection';
 import { PreferencesSection } from './sections/PreferencesSection/PreferencesSection';
@@ -54,6 +55,7 @@ interface SettingsModalProps {
 
 export function SettingsModal({ opened, onClose }: SettingsModalProps) {
   const [activeLabel, setActiveLabel] = useState('Preferences');
+  useFlushAnalyticsRefetchOnClose(opened);
 
   return (
     <Modal.Root

--- a/src/client/v2/src/components/SettingsModal/sections/ConnectedBanksSection/ConnectedBanksSection.tsx
+++ b/src/client/v2/src/components/SettingsModal/sections/ConnectedBanksSection/ConnectedBanksSection.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 import { useMutation, useQuery } from '@apollo/client/react';
+import { DeleteAuthenticationRequest } from '@graphql-mutations/DeleteAuthenticationRequest';
+import { GetAuthRequestsWithAccounts } from '@graphql-queries/GetAuthRequestsWithAccounts';
+import { AuthRequestWithAccountsFragment } from '@graphql-types/graphql';
 import { IconAlertCircle, IconBuildingBank } from '@tabler/icons-react';
 import { Alert, Button, Group, Loader, Modal, Stack, Text } from '@mantine/core';
-import { GetAuthRequestsWithAccounts } from '@graphql-queries/GetAuthRequestsWithAccounts';
-import { DeleteAuthenticationRequest } from '@graphql-mutations/DeleteAuthenticationRequest';
-import { AuthRequestWithAccountsFragment } from '@graphql-types/graphql';
 import { ConnectedBankCard } from './ConnectedBankCard';
 
 type AuthRequestWithAccounts = AuthRequestWithAccountsFragment;
@@ -53,7 +53,8 @@ export function ConnectedBanksSection() {
           Manage the bank connections used to sync your accounts and transactions.
         </Text>
         <Text size="xs" c="dimmed">
-          If an institution has multiple active connections, removing one will not affect account syncing as long as at least one connection remains.
+          If an institution has multiple active connections, removing one will not affect account
+          syncing as long as at least one connection remains.
         </Text>
       </Stack>
 
@@ -65,7 +66,11 @@ export function ConnectedBanksSection() {
           </Text>
         </Stack>
       ) : error ? (
-        <Alert color="red" icon={<IconAlertCircle size={16} />} title="Failed to load connected banks">
+        <Alert
+          color="red"
+          icon={<IconAlertCircle size={16} />}
+          title="Failed to load connected banks"
+        >
           {error.message}
         </Alert>
       ) : banks.length === 0 ? (

--- a/src/client/v2/src/graphql/types/graphql.ts
+++ b/src/client/v2/src/graphql/types/graphql.ts
@@ -28,6 +28,17 @@ export type AuthenticationRequest = {
   thirdPartyId: Scalars['UUID']['output'];
 };
 
+export type AuthenticationRequestFilterInput = {
+  and?: InputMaybe<Array<AuthenticationRequestFilterInput>>;
+  associatedAccounts?: InputMaybe<ListFilterInputTypeOfBankAccountFilterInput>;
+  authenticationLink?: InputMaybe<UrlOperationFilterInput>;
+  createdAt?: InputMaybe<DateTimeOperationFilterInput>;
+  id?: InputMaybe<UuidOperationFilterInput>;
+  or?: InputMaybe<Array<AuthenticationRequestFilterInput>>;
+  status?: InputMaybe<AuthenticationStatusOperationFilterInput>;
+  thirdPartyId?: InputMaybe<UuidOperationFilterInput>;
+};
+
 export type AuthenticationRequestInput = {
   associatedAccounts: Array<BankAccountInput>;
   authenticationLink: Scalars['URL']['input'];
@@ -46,6 +57,13 @@ export enum AuthenticationStatus {
   Unknown = 'UNKNOWN'
 }
 
+export type AuthenticationStatusOperationFilterInput = {
+  eq?: InputMaybe<AuthenticationStatus>;
+  in?: InputMaybe<Array<AuthenticationStatus>>;
+  neq?: InputMaybe<AuthenticationStatus>;
+  nin?: InputMaybe<Array<AuthenticationStatus>>;
+};
+
 export type BankAccount = {
   __typename: 'BankAccount';
   accountType: Maybe<Scalars['String']['output']>;
@@ -63,6 +81,26 @@ export type BankAccount = {
   ownerName: Maybe<Scalars['String']['output']>;
   thirdPartyId: Scalars['UUID']['output'];
   transactions: Array<Transaction>;
+};
+
+export type BankAccountFilterInput = {
+  accountType?: InputMaybe<StringOperationFilterInput>;
+  and?: InputMaybe<Array<BankAccountFilterInput>>;
+  associatedAuthenticationRequests?: InputMaybe<ListFilterInputTypeOfAuthenticationRequestFilterInput>;
+  associatedInstitution?: InputMaybe<BankingInstitutionFilterInput>;
+  balance?: InputMaybe<DecimalOperationFilterInput>;
+  bban?: InputMaybe<StringOperationFilterInput>;
+  bic?: InputMaybe<StringOperationFilterInput>;
+  currency?: InputMaybe<StringOperationFilterInput>;
+  description?: InputMaybe<StringOperationFilterInput>;
+  iban?: InputMaybe<StringOperationFilterInput>;
+  id?: InputMaybe<UuidOperationFilterInput>;
+  includeInAnalytics?: InputMaybe<BooleanOperationFilterInput>;
+  name?: InputMaybe<StringOperationFilterInput>;
+  or?: InputMaybe<Array<BankAccountFilterInput>>;
+  ownerName?: InputMaybe<StringOperationFilterInput>;
+  thirdPartyId?: InputMaybe<UuidOperationFilterInput>;
+  transactions?: InputMaybe<ListFilterInputTypeOfTransactionFilterInput>;
 };
 
 export type BankAccountInput = {
@@ -113,6 +151,17 @@ export type BankingInstitution = {
   thirdPartyId: Scalars['String']['output'];
 };
 
+export type BankingInstitutionFilterInput = {
+  and?: InputMaybe<Array<BankingInstitutionFilterInput>>;
+  bic?: InputMaybe<StringOperationFilterInput>;
+  countries?: InputMaybe<ListStringOperationFilterInput>;
+  id?: InputMaybe<UuidOperationFilterInput>;
+  logoUri?: InputMaybe<UrlOperationFilterInput>;
+  name?: InputMaybe<StringOperationFilterInput>;
+  or?: InputMaybe<Array<BankingInstitutionFilterInput>>;
+  thirdPartyId?: InputMaybe<StringOperationFilterInput>;
+};
+
 export type BankingInstitutionInput = {
   bic: Scalars['String']['input'];
   countries: Array<Scalars['String']['input']>;
@@ -140,6 +189,11 @@ export type BankingInstitutionsEdge = {
   cursor: Scalars['String']['output'];
   /** The item at the end of the edge. */
   node: BankingInstitution;
+};
+
+export type BooleanOperationFilterInput = {
+  eq?: InputMaybe<Scalars['Boolean']['input']>;
+  neq?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type CreateAuthenticationRequestInput = {
@@ -199,6 +253,36 @@ export type CreateTransactionPayload = {
   transaction: Maybe<Transaction>;
 };
 
+export type DateTimeOperationFilterInput = {
+  eq?: InputMaybe<Scalars['DateTime']['input']>;
+  gt?: InputMaybe<Scalars['DateTime']['input']>;
+  gte?: InputMaybe<Scalars['DateTime']['input']>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  lt?: InputMaybe<Scalars['DateTime']['input']>;
+  lte?: InputMaybe<Scalars['DateTime']['input']>;
+  neq?: InputMaybe<Scalars['DateTime']['input']>;
+  ngt?: InputMaybe<Scalars['DateTime']['input']>;
+  ngte?: InputMaybe<Scalars['DateTime']['input']>;
+  nin?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  nlt?: InputMaybe<Scalars['DateTime']['input']>;
+  nlte?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+export type DecimalOperationFilterInput = {
+  eq?: InputMaybe<Scalars['Decimal']['input']>;
+  gt?: InputMaybe<Scalars['Decimal']['input']>;
+  gte?: InputMaybe<Scalars['Decimal']['input']>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['Decimal']['input']>>>;
+  lt?: InputMaybe<Scalars['Decimal']['input']>;
+  lte?: InputMaybe<Scalars['Decimal']['input']>;
+  neq?: InputMaybe<Scalars['Decimal']['input']>;
+  ngt?: InputMaybe<Scalars['Decimal']['input']>;
+  ngte?: InputMaybe<Scalars['Decimal']['input']>;
+  nin?: InputMaybe<Array<InputMaybe<Scalars['Decimal']['input']>>>;
+  nlt?: InputMaybe<Scalars['Decimal']['input']>;
+  nlte?: InputMaybe<Scalars['Decimal']['input']>;
+};
+
 export type DeleteAuthenticationRequestInput = {
   /** The id of the authentication request to delete. */
   authenticationId: Scalars['UUID']['input'];
@@ -247,6 +331,41 @@ export type DeleteTransactionPayload = {
 
 export type Error = {
   message: Scalars['String']['output'];
+};
+
+export type ListFilterInputTypeOfAuthenticationRequestFilterInput = {
+  all?: InputMaybe<AuthenticationRequestFilterInput>;
+  any?: InputMaybe<Scalars['Boolean']['input']>;
+  none?: InputMaybe<AuthenticationRequestFilterInput>;
+  some?: InputMaybe<AuthenticationRequestFilterInput>;
+};
+
+export type ListFilterInputTypeOfBankAccountFilterInput = {
+  all?: InputMaybe<BankAccountFilterInput>;
+  any?: InputMaybe<Scalars['Boolean']['input']>;
+  none?: InputMaybe<BankAccountFilterInput>;
+  some?: InputMaybe<BankAccountFilterInput>;
+};
+
+export type ListFilterInputTypeOfTagFilterInput = {
+  all?: InputMaybe<TagFilterInput>;
+  any?: InputMaybe<Scalars['Boolean']['input']>;
+  none?: InputMaybe<TagFilterInput>;
+  some?: InputMaybe<TagFilterInput>;
+};
+
+export type ListFilterInputTypeOfTransactionFilterInput = {
+  all?: InputMaybe<TransactionFilterInput>;
+  any?: InputMaybe<Scalars['Boolean']['input']>;
+  none?: InputMaybe<TransactionFilterInput>;
+  some?: InputMaybe<TransactionFilterInput>;
+};
+
+export type ListStringOperationFilterInput = {
+  all?: InputMaybe<StringOperationFilterInput>;
+  any?: InputMaybe<Scalars['Boolean']['input']>;
+  none?: InputMaybe<StringOperationFilterInput>;
+  some?: InputMaybe<StringOperationFilterInput>;
 };
 
 /** AuthenticationRequest related mutation resolvers. */
@@ -441,6 +560,7 @@ export type QueryBankAccountsArgs = {
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<BankAccountFilterInput>;
 };
 
 
@@ -488,6 +608,21 @@ export type SetBankAccountIncludeInAnalyticsPayload = {
   bankAccount: Maybe<BankAccount>;
 };
 
+export type StringOperationFilterInput = {
+  and?: InputMaybe<Array<StringOperationFilterInput>>;
+  contains?: InputMaybe<Scalars['String']['input']>;
+  endsWith?: InputMaybe<Scalars['String']['input']>;
+  eq?: InputMaybe<Scalars['String']['input']>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  ncontains?: InputMaybe<Scalars['String']['input']>;
+  nendsWith?: InputMaybe<Scalars['String']['input']>;
+  neq?: InputMaybe<Scalars['String']['input']>;
+  nin?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  nstartsWith?: InputMaybe<Scalars['String']['input']>;
+  or?: InputMaybe<Array<StringOperationFilterInput>>;
+  startsWith?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type SynchronizeAuthenticationRequestDataPayload = {
   __typename: 'SynchronizeAuthenticationRequestDataPayload';
   boolean: Maybe<Scalars['Boolean']['output']>;
@@ -517,6 +652,16 @@ export type Tag = {
   transactions: Array<Transaction>;
 };
 
+export type TagFilterInput = {
+  and?: InputMaybe<Array<TagFilterInput>>;
+  color?: InputMaybe<StringOperationFilterInput>;
+  description?: InputMaybe<StringOperationFilterInput>;
+  id?: InputMaybe<UuidOperationFilterInput>;
+  name?: InputMaybe<StringOperationFilterInput>;
+  or?: InputMaybe<Array<TagFilterInput>>;
+  transactions?: InputMaybe<ListFilterInputTypeOfTransactionFilterInput>;
+};
+
 export type TagInput = {
   color: Scalars['String']['input'];
   description: Scalars['String']['input'];
@@ -539,6 +684,23 @@ export type Transaction = {
   tags: Array<Tag>;
   thirdPartyId: Scalars['UUID']['output'];
   valueDate: Maybe<Scalars['DateTime']['output']>;
+};
+
+export type TransactionFilterInput = {
+  amount?: InputMaybe<DecimalOperationFilterInput>;
+  and?: InputMaybe<Array<TransactionFilterInput>>;
+  bankAccount?: InputMaybe<BankAccountFilterInput>;
+  bankTransactionId?: InputMaybe<StringOperationFilterInput>;
+  category?: InputMaybe<StringOperationFilterInput>;
+  currency?: InputMaybe<StringOperationFilterInput>;
+  id?: InputMaybe<UuidOperationFilterInput>;
+  notes?: InputMaybe<StringOperationFilterInput>;
+  or?: InputMaybe<Array<TransactionFilterInput>>;
+  payee?: InputMaybe<StringOperationFilterInput>;
+  payer?: InputMaybe<StringOperationFilterInput>;
+  tags?: InputMaybe<ListFilterInputTypeOfTagFilterInput>;
+  thirdPartyId?: InputMaybe<UuidOperationFilterInput>;
+  valueDate?: InputMaybe<DateTimeOperationFilterInput>;
 };
 
 export type TransactionInput = {
@@ -604,6 +766,36 @@ export type UpdateTransactionInput = {
 export type UpdateTransactionPayload = {
   __typename: 'UpdateTransactionPayload';
   transaction: Maybe<Transaction>;
+};
+
+export type UrlOperationFilterInput = {
+  eq?: InputMaybe<Scalars['URL']['input']>;
+  gt?: InputMaybe<Scalars['URL']['input']>;
+  gte?: InputMaybe<Scalars['URL']['input']>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['URL']['input']>>>;
+  lt?: InputMaybe<Scalars['URL']['input']>;
+  lte?: InputMaybe<Scalars['URL']['input']>;
+  neq?: InputMaybe<Scalars['URL']['input']>;
+  ngt?: InputMaybe<Scalars['URL']['input']>;
+  ngte?: InputMaybe<Scalars['URL']['input']>;
+  nin?: InputMaybe<Array<InputMaybe<Scalars['URL']['input']>>>;
+  nlt?: InputMaybe<Scalars['URL']['input']>;
+  nlte?: InputMaybe<Scalars['URL']['input']>;
+};
+
+export type UuidOperationFilterInput = {
+  eq?: InputMaybe<Scalars['UUID']['input']>;
+  gt?: InputMaybe<Scalars['UUID']['input']>;
+  gte?: InputMaybe<Scalars['UUID']['input']>;
+  in?: InputMaybe<Array<InputMaybe<Scalars['UUID']['input']>>>;
+  lt?: InputMaybe<Scalars['UUID']['input']>;
+  lte?: InputMaybe<Scalars['UUID']['input']>;
+  neq?: InputMaybe<Scalars['UUID']['input']>;
+  ngt?: InputMaybe<Scalars['UUID']['input']>;
+  ngte?: InputMaybe<Scalars['UUID']['input']>;
+  nin?: InputMaybe<Array<InputMaybe<Scalars['UUID']['input']>>>;
+  nlt?: InputMaybe<Scalars['UUID']['input']>;
+  nlte?: InputMaybe<Scalars['UUID']['input']>;
 };
 
 export type AuthRequestWithAccountsFragment = { __typename: 'AuthenticationRequest', id: unknown | null, thirdPartyId: unknown, status: AuthenticationStatus, authenticationLink: unknown, createdAt: Date, associatedAccounts: Array<{ __typename: 'BankAccount', id: unknown | null, thirdPartyId: unknown, iban: string | null, name: string | null, description: string | null, accountType: string | null, balance: number | null, currency: string | null, ownerName: string | null, includeInAnalytics: boolean, associatedInstitution: { __typename: 'BankingInstitution', name: string, bic: string, logoUri: unknown } | null }> };

--- a/src/client/v2/src/layouts/AppLayout.tsx
+++ b/src/client/v2/src/layouts/AppLayout.tsx
@@ -1,6 +1,7 @@
 import { IconGauge, IconNotes, IconPresentationAnalytics } from '@tabler/icons-react';
 import { Outlet } from 'react-router-dom';
 import { useDisclosure } from '@mantine/hooks';
+import { DeferredAnalyticsRefetchProvider } from '@/components/IncludeInAnalyticsSwitch/DeferredAnalyticsRefetch';
 import { Navbar } from '@/components/Navbar/Navbar';
 import { LinksGroupProps } from '@/components/NavbarLinksGroup/NavbarLinksGroup';
 import { SettingsModal } from '@/components/SettingsModal/SettingsModal';
@@ -15,12 +16,14 @@ export function AppLayout() {
   ];
 
   return (
-    <div style={{ display: 'flex', height: '100vh' }}>
-      <Navbar links={navLinks} onUserProfileClick={openSettings} />
-      <main style={{ flex: 1, overflow: 'auto', padding: 'var(--mantine-spacing-md)' }}>
-        <Outlet />
-      </main>
-      <SettingsModal opened={settingsOpened} onClose={closeSettings} />
-    </div>
+    <DeferredAnalyticsRefetchProvider>
+      <div style={{ display: 'flex', height: '100vh' }}>
+        <Navbar links={navLinks} onUserProfileClick={openSettings} />
+        <main style={{ flex: 1, overflow: 'auto', padding: 'var(--mantine-spacing-md)' }}>
+          <Outlet />
+        </main>
+        <SettingsModal opened={settingsOpened} onClose={closeSettings} />
+      </div>
+    </DeferredAnalyticsRefetchProvider>
   );
 }

--- a/src/client/v2/src/pages/Accounts/Accounts.page.tsx
+++ b/src/client/v2/src/pages/Accounts/Accounts.page.tsx
@@ -50,9 +50,15 @@ export function AccountsPage() {
   const [accountId, setAccountId] = useState<string | null>(null);
 
   // Auto-select the first account once the accounts query resolves, so the page
-  // shows transactions immediately instead of an empty selector.
+  // shows transactions immediately instead of an empty selector. Also recovers the
+  // selection if the currently selected account leaves the list (e.g. the user
+  // excludes it from analytics in the connected banks settings).
   useEffect(() => {
-    if (!accountId && accounts.length > 0) {
+    if (accounts.length === 0) {
+      return;
+    }
+    const selectionExists = accountId != null && accounts.some((a) => String(a.id) === accountId);
+    if (!selectionExists) {
       setAccountId(String(accounts[0].id));
     }
   }, [accounts, accountId]);


### PR DESCRIPTION
## What & why

Builds on the server-side `includeInAnalytics` filtering (already on `main`) to make the frontend react to inclusion changes without a manual page reload.

Previously, toggling a bank account's *Include in analytics* switch in the Connected Banks settings (or the add-account flow) did not update the accounts view or net worth chart until the page was hard-reloaded — the analytics queries filter server-side on `includeInAnalytics`, which Apollo can't re-evaluate against its normalized cache. A first attempt that refetched on every toggle caused churn (it collapsed the connected banks account accordion mid-interaction).

This PR defers the refetch to when the user closes the hosting modal, and batches it into a single refetch.

## Changes

- **`DeferredAnalyticsRefetch.tsx` (new)** — a provider mounted once in `AppLayout`, plus two hooks:
  - `useMarkAnalyticsDirty()` — the `IncludeInAnalyticsSwitch` calls this on toggle to flag the analytics queries as stale (global context, works regardless of which modal it's in).
  - `useFlushAnalyticsRefetchOnClose(opened)` — flushes a single `refetchQueries([GetBankAccounts, GetNetWorthHistory])` when a surface's `opened` prop transitions to `false`, and only if something was actually changed.
- **Both toggle surfaces are wired**: `SettingsModal` (Connected Banks) and `AddAccountModal` (add-account success step) each call `useFlushAnalyticsRefetchOnClose(opened)`. Both render under the single `AppLayout` provider.
- **`IncludeInAnalyticsSwitch`** — dropped the per-toggle `refetchQueries`; it now marks dirty and keeps its optimistic update so the switch/list still feel instant.
- **`Accounts.page.tsx`** — recover the selected account when the currently viewed account leaves the list after being excluded (previously left a `—` header + stale transactions).
- **`graphql.ts`** — regenerated types (includes the filter input types from the server-side filtering change).

## Behavior

- Toggle accounts → switches flip instantly, the connected banks accordion stays expanded, no mid-interaction churn.
- Close the settings / add-account modal → the accounts view and net worth chart refetch once and reflect all changes.
- No toggles touched → closing the modal does nothing extra.

## Reviewer notes

- The dirty flag lives in one app-wide provider rather than per-modal. Only one of these modals can be open at a time and each close flushes+resets, so this is fine. Edge case: dismissing a modal by navigating away (instead of closing it) defers the flush to the next modal close — harmless, just slightly later. Happy to add a route-change flush if you'd prefer to close that gap.
- Verified locally: `typecheck`, `eslint`, and the full vitest suite (65 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
